### PR TITLE
Docker for dev and solr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  rcloud:
+    image: rcdev
+    ports:
+      - "8080:8080"
+    depends_on: 
+      - solr
+    volumes:
+      # This one stores the gists
+      - .\data:/data/rcloud/data
+      # This one loads any code in that you are likely to have changed
+      - .\rcloud.support:/data/rcloud/rcloud.support # so we don't have to full rebuild every time
+      - ..\rcloud.solr:/data/rcloud/rcloud.packages/rcloud.solr
+  solr:
+    image: rcsolr
+    ports:
+      - "8983:8983"

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+sudo su - rcloud -c "ROOT=/data/rcloud /data/rcloud/scripts/build.sh --core"
 sudo su - rcloud -c "ROOT=/data/rcloud /data/rcloud/conf/start"
 sudo su - rcloud -c "/data/rcloud/docker/ulogd/ulogd /data/rcloud/run/ulog"

--- a/docker/rcloud.conf
+++ b/docker/rcloud.conf
@@ -6,6 +6,7 @@ gist.backend: gitgist
 gist.git.root: ${ROOT}/data/gists
 rcloud.alluser.addons: rcloud.viewer, rcloud.enviewer, rcloud.notebook.info, rcloud.logo
 rcloud.languages: rcloud.r, rcloud.python, rcloud.rmarkdown, rcloud.sh
+solr.url: http://solr:8983/solr/rcloudnotebooks
 #compute.separation.modes: IDE
 rcloud.deployment: Docker
 rcloud.deployment.color: orange


### PR DESCRIPTION
Allows Docker to be used for development.

- Builds core packages on launch
- Solr is in its own container

docker-compose organises everything. Just run 
```
docker-compose up -d
```